### PR TITLE
GREEN-837: Add SELENIUM_JAVA_JUNIT as browser test type

### DIFF
--- a/src/main/java/com/testlio/plugins/jenkins/enums/BrowserTestTypeEnum.java
+++ b/src/main/java/com/testlio/plugins/jenkins/enums/BrowserTestTypeEnum.java
@@ -2,6 +2,7 @@ package com.testlio.plugins.jenkins.enums;
 
 public enum BrowserTestTypeEnum {
     SELENIUM_JAVA_TESTNG("Selenium Java TestNG"),
+    SELENIUM_JAVA_JUNIT("Selenium Java JUnit"),
     SELENIUM_NODE("Selenium Node");
 
     private final String name;


### PR DESCRIPTION
#### JIRA
[GREEN-837](https://testlions.atlassian.net/browse/GREEN-837)

#### Related PRs
N/A

#### Background and Solution
Adds `SELENIUM_JAVA_JUNIT` as a dropdown option when selecting the test type for a browser run.

#### Testing Strategy
1. See if `SELENIUM_JAVA_JUNIT` shows as a dropdown option.

#### Are the Changes Covered With Tests?
- [ ] Yes
- [X] No

#### Does This Introduce a Breaking Change to the API?
- [ ] Yes
- [X] No

#### Is the Documentation Updated/Provided?
- [ ] Yes
- [X] No
